### PR TITLE
Correct gatsby-plugin-remark to gatsby-transformer-remark

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ module.exports = {
         ]
       },
     },
-    "gatsby-plugin-remark"
+    "gatsby-transformer-remark"
   }
 }
 ```


### PR DESCRIPTION
The README had a small mistake, mentioning the `gatsby-transformer-remark` plugin by an incorrect name.